### PR TITLE
Up min version of squizlabs/php_codesniffer lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "squizlabs/php_codesniffer": "~2.0"
+    "squizlabs/php_codesniffer": "^3.0"
   }
 }


### PR DESCRIPTION
Lib PHP_codesniffer 2 is not supported in the latest versions of PHP.